### PR TITLE
v1.1.0

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -15,6 +15,8 @@ engines:
     enabled: true
   fixme:
     enabled: true
+  scss-lint:
+    enabled: true
 ratings:
   paths:
   - 'public/**'

--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -1,0 +1,1 @@
+scss_files: 'public/styles/**/*.scss'

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,14 +21,3 @@ branches:
   only:
   - master
   - dev
-
-# Setup compiler environment. Utilize G++ 4.8 over default compiler.
-env:
-  matrix:
-  - CXX=g++-4.8
-addons:
-  apt:
-    sources:
-    - ubuntu-toolchain-r-test
-    packages:
-    - g++-4.8

--- a/config
+++ b/config
@@ -12,7 +12,7 @@ auth.emails  (Object)    : ['postmaster@localhost']
 
 // Wiki Information
 wiki.name     : Skribki
-wiki.icon     : /img/icon.svg
+wiki.icon     : /img/logo.svg
 wiki.lang     : en-us
 
 // Content Licensing

--- a/config
+++ b/config
@@ -8,7 +8,7 @@ auth.cookie   : __skrSS
 // emails may be a string or a valid JavaScript regular expression
 // string matches are case sensitive!
 auth.whitelist (boolean) : false
-auth.emails  (Object)    : ['postmaster@localhost']
+auth.emails  (Object)    : [/@localhost$/i, 'user@example.com']
 
 // Wiki Information
 wiki.name     : Skribki

--- a/controllers/page.js
+++ b/controllers/page.js
@@ -8,7 +8,7 @@ exports.install = () => {
   F.route(r => { return !F.locked(r); }, deletePage, [ 'delete' ]);
 };
 
-/* eslint complexity: ['error', 7] */
+/* eslint complexity: ["error", 7] */
 function routePage() {
   let page = F.model('page');
   switch (this.query.a || '') {

--- a/definitions/routing.js
+++ b/definitions/routing.js
@@ -2,7 +2,8 @@
 
 const LOCKED = [
   /^\/special\//i, // Special pages/directores
-  /^\/categor(?:y|ies)\//i
+  /^\/categor(?:y|ies)\//i,
+  /^\/\./ // anything that starts with a dot
 ];
 
 F.lockedPatterns = LOCKED;
@@ -20,11 +21,11 @@ F.middleware('public-files', (req, res, next) => {
 });
 F.use('public-files');
 
-Controller.prototype.viewError = function (code, url, info) {
+Controller.prototype.viewError = function (code, url = this.url, info) {
   this.repository.title = F.localize(this.req, 'error.header', [ code ]);
   this.view('error', {
     errno: code,
-    url: url || this.url,
+    url: url,
     info: info
   });
 }
@@ -44,4 +45,6 @@ Controller.prototype.view707 = Controller.prototype.view707 = function () {
 F.on('error404', (req, res, exception) => {
   if (req.url.startsWith('/special'))
     res.redirect(req.url.substring(8));
+  else if (req.url.startsWith('/.'))
+    res.redirect('/' + req.url.substring(2));
 });

--- a/models/page.js
+++ b/models/page.js
@@ -49,20 +49,25 @@ exports.uninstall = () => {
   lockfile.unlockSync(F.path.wiki('repo.lck'));
 };
 
-exports.normalizePath = route => {
+exports.normalizePath = (route = '') => {
   assert.strictEqual(typeof route, 'string', 'route should be a string');
 
-  // normalize to root to avoid stepping out of cwd
-  if (!route.startsWith('/')) route = '/' + route;
-  if (route.endsWith('/')) route = route.slice(0, -1);
-  route = path.normalize(route);
+  // remove any leading dots (non-leading dots are handled later)
+  while (route.startsWith('.')) route = route.substring(1);
 
+  // normalize slashes
+  if (route.endsWith('/')) route = route.slice(0, -1);
+  if (!route.startsWith('/')) route = '/' + route;
+
+  // normalize the path
+  route = path.normalize(route);
   return route;
 };
 
 exports.workingFile = route => {
   let deferred = q.defer();
   route = exports.normalizePath(route);
+  if (route === '/') route = '';
 
   fs.stat(path.join(exports.wikiPath, route), (err, stats) => {
     if (err) return deferred.resolve(); // missing file means we resolve with no data.
@@ -88,9 +93,7 @@ exports.read = route => {
 exports.modifyFile = (rt, func) => {
   let deferred = q.defer();
 
-  exports.workingFile(rt).then(route => {
-    route = route ? route : '.' + exports.normalizePath(rt);
-    if (route === '.') return deferred.reject(new Error('cannot create file at "/"'));
+  exports.workingFile(rt).then((route = exports.normalizePath(rt)) => {
 
     // lock the file to avoid any weird commits with two simultanious edits
     // wait 2 seconds for other locks to be released
@@ -118,7 +121,7 @@ exports.write = (rt, data) => {
   return exports.modifyFile(rt, (route, done) => {
     fs.writeFile(F.path.wiki(route), data.body, err => {
       if (err) return done(err);
-      F.repository.add(route)
+      F.repository.add('.' + route)
         .commit(data.message || 'Update ' + route, { '--author': `"${data.name} <${data.email}>"` }, done);
     });
   });
@@ -181,22 +184,15 @@ exports.parse = body => {
   return deferred.promise;
 };
 
-exports.history = (route) => {
-  assert.equal(typeof route, 'string', 'route must be a string');
-  route = exports.normalizePath(route);
-
+exports.history = rt => {
+  assert.equal(typeof rt, 'string', 'route must be a string');
   let deferred = q.defer();
 
-  fs.stat(F.path.wiki(route), (err, stats) => {
-    if (!err && stats.isDirectory()) {
-      route += '/index';
-      return deferred.resolve(exports.history(route));
-    } else {
-      F.repository.log(['--', route.substring(1)], (err, results) => {
-        if (err) deferred.reject(err);
-        deferred.resolve(results.all);
-      });
-    }
+  exports.workingFile(rt).then((route = exports.normalizePath(rt)) => {
+    F.repository.log(['--', route.substring(1)], (err, results) => {
+      if (err) deferred.reject(err);
+      deferred.resolve(results.all);
+    });
   });
 
   return deferred.promise;

--- a/models/page.js
+++ b/models/page.js
@@ -118,7 +118,7 @@ exports.write = (rt, data) => {
   return exports.modifyFile(rt, (route, done) => {
     fs.writeFile(F.path.wiki(route), data.body, err => {
       if (err) return done(err);
-      F.repository.add('.' + route)
+      F.repository.add(route)
         .commit(data.message || 'Update ' + route, { '--author': `"${data.name} <${data.email}>"` }, done);
     });
   });

--- a/modules/pug.js
+++ b/modules/pug.js
@@ -37,7 +37,7 @@ const createParserFunction = (self, key, name, filename) => {
 
 exports.install = opts => {
   frameworkEngine = Controller.prototype.view;
-  /* eslint complexity: ['error', 7] */
+  /* eslint complexity: ["error", 7] */
   Controller.prototype.view = function (name, model = { }, headers, isPartial) {
     let self = this;
 

--- a/modules/scss.js
+++ b/modules/scss.js
@@ -10,7 +10,10 @@ exports.compile = (content) => {
       outputStyle: 'compressed',
       includePaths: [ F.path.public('/styles/partials') ]
     }).css.toString();
-  } catch (e) { return ''; }
+  } catch (e) {
+    console.log(e.stack);
+    return '';
+  }
 };
 
 exports.install = () => {

--- a/modules/scss.js
+++ b/modules/scss.js
@@ -22,7 +22,7 @@ exports.install = () => {
   };
 };
 
-/* eslint complexity: ['error', 7] */
+/* eslint complexity: ["error", 7] */
 function scssCompiler(req, res, isValidation) {
   if (isValidation)
     return req.url.endsWith('.scss') || req.url.endsWith('.sass');

--- a/package.json
+++ b/package.json
@@ -39,5 +39,8 @@
     "q": "^1.4.1",
     "simple-git": "^1.65.0",
     "total.js": "^2.3.0"
+  },
+  "devDependencies": {
+    "expect.js": "^0.3.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skribki",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "An open-source wiki software based on git.",
   "main": "release.js",
   "private": true,

--- a/public/styles/error.scss
+++ b/public/styles/error.scss
@@ -1,10 +1,12 @@
-section#content {
+@import '../page';
+
+.content-page {
   text-align: center;
   p { font-size: 14pt; }
   pre {
-    text-align: left;
-    border: 1px rgba(0,0,0,0.05) solid;
+    border: 1px rgba($color-black, .05) solid;
     border-radius: 0;
-    color: #777;
+    color: tint($color-gray, 20%);
+    text-align: left;
   }
 }

--- a/public/styles/history.scss
+++ b/public/styles/history.scss
@@ -3,24 +3,30 @@
 .commit {
   a {
     display: inline-block;
-    font-weight: bold;
-    font-size: 12pt;
     font-family: monospace;
+    font-size: 12pt;
+    font-weight: bold;
     padding-right: 10px;
-    &:hover, &:focus {
+
+    &:hover,
+    &:focus {
       text-decoration: none;
     }
   }
+
   strong {
     font-size: 12pt;
     padding: 0 5px;
   }
+
   .commit-email {
     font-family: monospace;
     padding: 0 4px;
   }
+
   .commit-date {
     font-size: 8pt;
-    opacity: 0.6;
+    opacity: .6;
   }
+
 }

--- a/public/styles/layout.scss
+++ b/public/styles/layout.scss
@@ -1,18 +1,8 @@
-/**
-  * Skribki layout styles
-  */
-
-// clean the page up a bit
-* { box-sizing: border-box; }
-body {
-  padding-top: 50px;
-  background-color: #d8d8d8;
-  font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
-  &, html { margin: 0; }
-}
+//
+// Skribki layout styles
+//
 
 @import 'colors';
-@import 'functions';
 
 // layout partials
 @import 'header';
@@ -22,6 +12,17 @@ body {
 
 // layouts
 @import 'layout-sidebar';
+
+// clean the page up a bit
+* { box-sizing: border-box; }
+body {
+  background-color: $color-lightgray;
+  font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  padding-top: 50px;
+
+  &,
+  html { margin: 0; }
+}
 
 // generic styles
 @media screen and (min-width: 1400px) {

--- a/public/styles/login.scss
+++ b/public/styles/login.scss
@@ -2,7 +2,9 @@
 
 .btn-login {
   transition: 250ms;
-  &:hover, &:focus {
-    opacity: 0.9;
+
+  &:hover,
+  &:focus {
+    opacity: .9;
   }
 }

--- a/public/styles/page.scss
+++ b/public/styles/page.scss
@@ -1,49 +1,62 @@
+@import 'colors';
+
 .content-page {
   // paragraph
   p {
+    color: $color-gray;
     padding: 0 10px;
-    color: #555;
     text-indent: 10px;
   }
+
   code {
-    background-color: #f8f8f8;
-    color: #999;
+    background-color: $color-white;
     border-radius: 2px;
+    color: tint($color-gray, 40%);
     padding: 2px 5px;
   }
 
 
   // headers
   h1 {
+    border-bottom: 1px rgba($color-black, .1) solid;
+    color: $color-gray;
     font-family: 'Raleway Black', sans-serif;
     font-size: 30pt;
-    border-bottom: 1px rgba(0,0,0,0.1) solid;
-    color: #555;
   }
-  h2, h3, h4, h5, h6 {
+
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
     font-family: Raleway, sans-serif;
   }
+
   h2 {
-    font-weight: bold;
+    color: tint($color-gray, 20%);
     font-size: 20pt;
-    color: #777;
+    font-weight: bold;
   }
+
   h3 {
-    font-weight: bold;
+    color: tint($color-gray, 20%);
     font-size: 16pt;
-    color: #777;
-  }
-  h4 {
-    font-size: 14pt;
-    color: #777;
-  }
-  h5 {
     font-weight: bold;
-    font-size: 13pt;
-    color: #999;
   }
+
+  h4 {
+    color: tint($color-gray, 20%);
+    font-size: 14pt;
+  }
+
+  h5 {
+    color: tint($color-gray, 40%);
+    font-size: 13pt;
+    font-weight: bold;
+  }
+
   h6 {
+    color: tint($color-gray, 40%);
     font-size: 12pt;
-    color: #999;
   }
 }

--- a/public/styles/partials/_colors.scss
+++ b/public/styles/partials/_colors.scss
@@ -1,15 +1,35 @@
-/**
-  * Skribki global colors
-  */
-
 // generic
+$color-white: #fff;
+$color-black: #000;
+$color-gray: #555;
+$color-lightgray: #d8d8d8;
+
+$color-red1: #e74c3c;
+$color-red2: #c0392b;
+$color-orange1: #e67e22;
+$color-orange2: #d35400;
+$color-yellow1: #f1c40f;
+$color-yellow2: #f39c12;
+$color-green1: #2ecc71;
+$color-green2: #27ae60;
+$color-blue1: #3498db;
+$color-blue2: #2980b9;
+$color-purple1: #9b59b6;
+$color-purple2: #8e44ad;
+
+@import 'functions';
+
+// layout
 $color-light-fg: #333;
 $color-light-bg: #f5f5f5;
 $color-dark-fg: $color-light-bg;
 $color-dark-bg: $color-light-fg;
 
+// banner
+$color-banner-bg: #34495e;
+$color-banner-fg: #bdc3c7;
+
 // base
 $color-base-1: #0ac;
-$color-base-2: $color-base-1 - #111;
-$color-base-fg: #D5E1E4;
-//$color-base-fg: #f5f5f5;
+$color-base-2: shade($color-base-1, 10%);
+$color-base-fg: #d5e1e4;

--- a/public/styles/partials/_footer.scss
+++ b/public/styles/partials/_footer.scss
@@ -1,5 +1,5 @@
 footer {
-  opacity: 0.4;
+  opacity: .4;
   .container { padding: 20px 0; }
   .langs {
     font-size: 8pt;

--- a/public/styles/partials/_functions.scss
+++ b/public/styles/partials/_functions.scss
@@ -1,7 +1,8 @@
 // tint and shade functions
 @function tint($color, $perc) {
-  @return mix(white, $color, $perc);
+  @return mix($color-white, $color, $perc);
 }
+
 @function shade($color, $perc) {
-  @return mix(black, $color, $perc)
+  @return mix($color-black, $color, $perc)
 }

--- a/public/styles/partials/_header.scss
+++ b/public/styles/partials/_header.scss
@@ -1,37 +1,42 @@
-#header {
+.jumbotron-header {
   background-color: $color-base-1;
+  color: $color-dark-fg;
   margin: 0;
   padding: 60px 10%;
-  color: $color-dark-fg;
+
   h1 {
+    font-family: 'Raleway Black', sans-serif;
+    font-weight: bold;
     margin: 0;
     margin-bottom: 10px;
-    font-weight: bold;
-    font-family: 'Raleway Black', sans-serif;
   }
+
   h2 {
-    margin: 0;
+    color: $color-base-fg;
     font-size: 21px;
     font-weight: lighter;
-    color: $color-base-fg;
+    margin: 0;
   }
 }
 
-#banner {
+.banner {
+  background-color: $color-banner-bg;
+  border-bottom: 1px shade($color-banner-bg, 10%) solid;
+  color: $color-banner-fg;
   padding: 15px 20px;
-  background-color: #34495e;
-  border-bottom: 1px #34495e solid;
-  color: #bdc3c7;
+
   p {
     display: inline;
   }
+
   .banner-dash {
     display: inline-block;
+    opacity: .5;
     padding: 0 5px;
-    opacity: 0.5;
   }
+
   a {
-    font-weight: bold;
     color: $color-base-1;
+    font-weight: bold;
   }
 }

--- a/public/styles/partials/_layout-content.scss
+++ b/public/styles/partials/_layout-content.scss
@@ -1,27 +1,31 @@
-#body {
-  background-color: #fff - #111;
-  padding-bottom: 50px;
+.section-body {
+  background-color: shade($color-white, 10%);
+  box-shadow: 0 1px 6px rgba($color-black, .2);
   min-height: 50vh;
-  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.2);
+  padding-bottom: 50px;
 }
 
-#content {
-  background-color: #fff;
+.section-content {
+  background-color: $color-white;
+  border-radius: 0 0 5px 5px;
+  box-shadow: 0 2px 4px rgba($color-black, .1);
+  margin-top: 0;
   min-height: 40px;
   padding: 20px 40px;
-  margin-top: 0;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-  border-radius: 0 0 5px 5px;
+
   .content-options > a {
-    padding: 5px 10px;
-    display: inline-block;
-    transition: opacity 250ms;
     color: $color-base-1;
-    &:hover, &:focus {
-      text-decoration: none;
-      opacity: 0.7;
+    display: inline-block;
+    padding: 5px 10px;
+    transition: opacity 250ms;
+
+    &:hover,
+    &:focus {
       color: $color-base-1;
+      opacity: .7;
+      text-decoration: none;
     }
-    &.danger { color: #e74c3c; }
+
+    &.danger { color: $color-red1; }
   }
 }

--- a/public/styles/partials/_layout-sidebar.scss
+++ b/public/styles/partials/_layout-sidebar.scss
@@ -1,43 +1,53 @@
 @import 'layout-content';
 
-#sidebar {
+.section-sidebar {
   padding: 10px;
 //  background-color: $color-light-bg - #111;
+
   img {
     max-width: 100%;
     padding: 20px;
   }
+
   a {
-    display: block;
+    border-right: 0 $color-base-1 solid;
     color: $color-base-1;
+    display: block;
+    padding-left: 30px;
     text-decoration: none;
     transition: 250ms;
-    padding-left: 30px;
-    border-right: 0 $color-base-1 solid;
+
     &.sidebar-lg {
-      font-weight: bold;
       font-size: 12pt;
+      font-weight: bold;
       margin: 10px 0;
     }
+
     &.sidebar-md {
       font-size: 10pt;
       margin: 5px 0;
     }
+
     &.sidebar-sm {
       font-size: 8pt;
     }
-    &:hover, &:focus {
-      opacity: 0.6;
+
+    &:hover,
+    &:focus {
+      opacity: .6;
       padding-left: 35px;
     }
-    &:active, &.active {
+
+    &:active,
+    &.active {
       border-width: 1px;
     }
   }
+
   hr {
     border-color: $color-base-1;
     margin: 20px auto;
+    opacity: .2;
     width: 80%;
-    opacity: 0.2;
   }
 }

--- a/public/styles/partials/_layout-sidebar.scss
+++ b/public/styles/partials/_layout-sidebar.scss
@@ -3,6 +3,10 @@
 #sidebar {
   padding: 10px;
 //  background-color: $color-light-bg - #111;
+  img {
+    max-width: 100%;
+    padding: 20px;
+  }
   a {
     display: block;
     color: $color-base-1;

--- a/public/styles/partials/_navbar.scss
+++ b/public/styles/partials/_navbar.scss
@@ -1,14 +1,16 @@
 // navbar
 .navbar-brand {
-  vertical-align: middle;
   font-size: 16px;
-  & > img {
+  vertical-align: middle;
+
+  > img {
     display: inline-block;
     height: 100%;
-    vertical-align: middle;
     padding-right: 3px;
+    vertical-align: middle;
   }
-  & > span {
+
+  > span {
     display: inline-block;
     vertical-align: middle;
   }
@@ -17,27 +19,35 @@
 .navbar-default {
   background-color: $color-base-1;
   border-color: $color-base-2;
-  box-shadow: 0 1px 0 rgba(255,255,255,0.07);
+  box-shadow: 0 1px 0 rgba($color-white, .07);
   min-height: 60px;
+
   .navbar-brand {
     color: $color-base-fg;
-    transition: color 250ms;
     font-size: 20px;
     font-weight: lighter;
     height: 60px;
     padding: 18px;
-    &:hover, &:focus {
+    transition: color 250ms;
+
+    &:hover,
+    &:focus {
       color: $color-dark-fg;
     }
   }
+
   .navbar-nav > li {
+    // scss-lint:disable SelectorDepth, NestingDepth
     vertical-align: middle;
-    & > a {
+
+    > a {
       color: $color-base-fg;
-      transition: color 250ms;
-      padding: 20px;
       font-size: 14px;
-      &:hover, &:focus {
+      padding: 20px;
+      transition: color 250ms;
+
+      &:hover,
+      &:focus {
         color: $color-dark-fg;
       }
     }

--- a/public/styles/partials/_objects.scss
+++ b/public/styles/partials/_objects.scss
@@ -1,88 +1,103 @@
-$color-btn-success: mix( tint( green, 40% ), $color-base-1, 40% );
+$color-btn-success: mix($color-green1, $color-base-1, 40%);
 
 // paragraph styles
 .monospace { font-family: monospace; }
 
 // buttons
 .btn {
-  display: inline-block;
+  border: 0 $color-white solid;
+  border-bottom-width: 3px;
   border-radius: 0;
-  border: none;
+  color: rgba($color-white, .9);
+  display: inline-block;
+  font-size: 11pt;
+  margin: 0 5px;
+  outline: none;
   padding: 5px 15px;
   text-indent: 0;
-  margin: 0 5px;
-  color: rgba(255, 255, 255, 0.9);
   transition: 250ms;
-  font-size: 11pt;
   vertical-align: middle;
-  border: 0 white solid;
-  border-bottom-width: 3px;
-  outline: none !important;
-  &:hover, &:focus {
-    color: #f5f5f5;
-  }
-  &:active {
-    box-shadow: 0 3px 3px 0 rgba(0,0,0,0.3) inset;
-    padding-top: 8px;
-    padding-bottom: 2px;
+
+  &:hover,
+  &:focus {
+    color: $color-light-bg;
     outline: none;
   }
-  &.btn-lg {
-    padding: 10px 20px;
-    font-size: 13pt;
+
+  &:active {
+    box-shadow: 0 3px 3px 0 rgba($color-black, .3) inset;
+    outline: none;
+    padding-bottom: 2px;
+    padding-top: 8px;
   }
+
+  &.btn-lg {
+    font-size: 13pt;
+    padding: 10px 20px;
+  }
+
   &.btn-primary {
     background-color: $color-base-1;
-    border-color: shade( $color-base-1, 10% );
-    &:hover, &:focus {
-      background-color: tint( $color-base-1, 10% );
+    border-color: shade($color-base-1, 10%);
+
+    &:hover,
+    &:focus {
+      background-color: tint($color-base-1, 10%);
       border-color: $color-base-1;
     }
+
     &:active {
-      background-color: shade( $color-base-1, 15% );
-      border-color: shade( $color-base-1, 15% );
+      background-color: shade($color-base-1, 15%);
+      border-color: shade($color-base-1, 15%);
     }
   }
+
   &.btn-success {
     background-color: $color-btn-success;
-    border-color: shade( $color-btn-success, 10% );
-    &:hover, &:focus {
-      background-color: tint( $color-btn-success, 10% );
+    border-color: shade($color-btn-success, 10%);
+
+    &:hover,
+    &:focus {
+      background-color: tint($color-btn-success, 10%);
       border-color: $color-btn-success;
     }
+
     &:active {
-      background-color: shade( $color-btn-success, 15% );
-      border-color: shade( $color-btn-success, 15% );
+      background-color: shade($color-btn-success, 15%);
+      border-color: shade($color-btn-success, 15%);
     }
   }
 }
 
 // form elements
-input[type=text] {
+[type=text] {
+  background-color: rgba($color-black, .03);
+  border: 1px rgba($color-black, .07) solid;
+  color: $color-gray;
   display: inline-block;
   min-width: 30%;
-  vertical-align: middle;
   padding: 5px 15px;
-  background-color: rgba(0,0,0,0.03);
-  border: 1px rgba(0,0,0,0.07) solid;
   transition: 250ms;
-  color: #555;
+  vertical-align: middle;
+
   &:focus {
+    border-color: rgba($color-base-1, .3);
     outline: none;
-    border-color: rgba( $color-base-1, 0.3 )
   }
 }
+
 textarea {
+  background-color: rgba($color-black, .03);
+  border: 1px rgba($color-black, .07) solid;
+  color: $color-gray;
   display: block;
-  width: 100%;
   margin: 10px 0;
-  background-color: rgba(0,0,0,0.03);
-  border: 1px rgba(0,0,0,0.07) solid;
-  transition: 250ms;
-  color: #555;
   padding: 10px;
+  transition: 250ms;
+  width: 100%;
+
   &:focus {
+    border-color: rgba($color-base-1, .3);
     outline: none;
-    border-color: rgba( $color-base-1, 0.3 )
   }
 }

--- a/tests/definitions/routing.js
+++ b/tests/definitions/routing.js
@@ -1,15 +1,35 @@
 'use strict';
 
-const assert = require('assert');
+const assert = require('assert'),
+      expect = require('expect.js');
 
 exports.run = () => {
 
-  F.assert('definition:routing:locked', (next, name) => {
-    assert.ok(F.lockedPatterns, 'locked patterns are missing');
-    assert.ok(F.locked('/special/foo'), 'special paths should lock');
-    assert.ok(F.locked('/category/bar'), 'categories should lock');
-    assert.ok(!F.locked('/foo/bar'), 'all others should not lock');
+  F.assert('definition:routing#locked', next => {
+    expect(F.lockedPatterns).to.be.an('array');
+
+    expect(F.locked('/special/foo')).to.be(true);
+    expect(F.locked('/category/bar')).to.be(true);
+    expect(F.locked('/.git')).to.be(true);
+    expect(F.locked('/foo/bar')).to.be(false);
     next();
+  });
+
+  F.assert('definition:Controller.prototype#viewError', next => {
+    let code = 707, url = '/foo', info = 'foobar';
+    let context = {
+      repository: { },
+      req: { },
+      view: (view, model) => {
+        expect(view).to.be('error');
+
+        expect(model.errno).to.be(code);
+        expect(model.url).to.be(url);
+        expect(model.info).to.be(info);
+        next();
+      }
+    };
+    Controller.prototype.viewError.call(context, code, url, info);
   });
 
 };

--- a/tests/models/page.js
+++ b/tests/models/page.js
@@ -1,81 +1,130 @@
 'use strict';
 
-const assert = require('assert');
+const assert = require('assert'),
+      expect = require('expect.js');
 
 const fs    = require('fs'),
       path  = require('path');
 
 const TEST_PATH = '/test~';
 
+function resetCommit(cb) {
+  F.repository.reset(['HEAD^1', '--hard'], cb);
+}
+
 exports.run = () => {
   const page = F.model('page');
 
-  F.assert('models:page:install', next => {
-    fs.stat(F.path.wiki('repo.lck'), (err, stats) => {
-      assert.ifError(err);
-      assert.ok(stats.isFile(), 'repo should be locked');
-      assert.ok(fs.statSync(F.path.wiki('.git')).isDirectory(), 'repo should be valid git repo');
-      next();
-    });
-  });
+  F.assert('model:page#install', next => {
+    expect(F.path.wiki).to.be.a('function');
+    expect(F.repository).to.be.an('object');
 
-  F.assert('models:page:normalizePath', next => {
-    assert.equal(page.normalizePath('/foo/'), '/foo', 'should remove trailing slash');
-    assert.equal(page.normalizePath('../foo/bar'), '/foo/bar', 'should prevent up-stepping');
+    expect(fs.statSync).withArgs(F.path.wiki('repo.lck')).to.not.throwException();
+    expect(fs.statSync(F.path.wiki('repo.lck')).isFile()).to.be(true);
+
+    expect(fs.statSync).withArgs(F.path.wiki('.git')).to.not.throwException();
+    expect(fs.statSync(F.path.wiki('.git')).isDirectory()).to.be(true);
     next();
   });
 
-  F.assert('models:page:workingFile', next => {
+  F.assert('model:page#normalizePath', next => {
+    expect(page.normalizePath('foo/')).to.be('/foo');
+    expect(page.normalizePath('../foo/bar')).to.be('/foo/bar');
+    expect(page.normalizePath('/')).to.be('/');
+    expect(page.normalizePath()).to.be('/');
+    expect(page.normalizePath).withArgs(false).to.throwException();
+    next();
+  });
+
+  F.assert('model:page#workingFile', next => {
     fs.mkdirSync(F.path.wiki(TEST_PATH));
     page.workingFile(TEST_PATH).then(file => {
-      assert.equal(file, TEST_PATH + '/index', 'should fetch index of directory');
+
+      expect(file).to.be(TEST_PATH + '/index');
       fs.rmdirSync(F.path.wiki(TEST_PATH));
+
       return page.workingFile(TEST_PATH).then(file => {
-        assert.ok(!file, 'should return empty data on missing file');
-        next(); // file present condition tested in next test
+        expect(file).to.be(undefined);
+
+        return page.workingFile('/').then(file => {
+          expect(file).to.be('/index');
+          next(); // no need to test when the file is present, handled in next test
+        });
       });
     }).catch(assert.ifError).done();
   });
 
-  F.assert('models:page:read', next => {
-    page.read(TEST_PATH).then((data) => {
-      assert.ok(!data, 'missing file should not have data');
+  F.assert('model:page#read', next => {
+    page.read(TEST_PATH).then(data => {
+      expect(data).to.be(undefined);
+
       fs.writeFileSync(F.path.wiki(TEST_PATH), 'foobar');
-      return page.read(TEST_PATH).then((data) => {
-        assert.strictEqual(data, 'foobar', 'should read file contents');
+      return page.read(TEST_PATH).then(data => {
+        expect(data).to.be('foobar');
+
         fs.unlinkSync(F.path.wiki(TEST_PATH));
         next();
       });
     }).catch(assert.ifError).done();
   });
 
-  F.assert('models:page:write', next => {
-    page.write(TEST_PATH, {
-      name: 'Test User',
-      email: 'test@example.com',
-      body: 'foobarbaz'
+  F.assert('model:page#modifyFile', next => {
+    page.modifyFile(TEST_PATH, (rt, done) => {
+      expect(rt).to.be(TEST_PATH);
+      expect(fs.statSync).withArgs(F.path.wiki(TEST_PATH + '.lck')).to.not.throwException();
+      done();
     }).then(() => {
-      return page.read(TEST_PATH).then(data => {
-        assert.equal(data, 'foobarbaz', 'should have written file to disk');
-        F.repository.reset(['HEAD^1', '--hard'], next);
-      });
-    }).catch(assert.ifError).done();
-  });
-
-  F.assert('models:page:parseDocument', next => {
-    page.parseDocument('$title foo\n$desc bar\n\n*body*').then(res => {
-      assert.equal(res.header.title, 'foo', 'title should be from document');
-      assert.equal(res.header.desc, 'bar', 'description should be from document');
-
-      // no need to overly test parsing, should be handled in parser testing
-      assert.equal(res.body, '<p><em>body</em></p>\n', 'body should have been parsed');
+      expect(fs.statSync).withArgs(F.path.wiki(TEST_PATH + '.lck')).to.throwException(/^ENOENT/);
       next();
     }).catch(assert.ifError).done();
   });
 
-  F.assert('models:page:parseDocumentEmpty', next => {
-    page.parseDocument().then(res => {
-      assert.ok(!res, 'should yield empty response');
+  F.assert('model:page#write', next => {
+    page.write(TEST_PATH, {
+      name: 'Skribki',
+      email: 'skribki@localhost',
+      body: 'foobarbaz'
+    }).then(() => {
+      return page.read(TEST_PATH).then(data => {
+        expect(data).to.be('foobarbaz');
+        resetCommit(next);
+      });
+    }).catch(assert.ifError).done();
+  });
+
+  F.assert('model:page#delete', next => {
+    // we'll be deleting the index to test, since it has to already exist.
+    // fortunately, we roll the deletion commit back (hopefully)
+    page.delete('/', {
+      name: 'Skribki',
+      email: 'skribki@localhost'
+    }).then(() => {
+      expect(fs.statSync).withArgs(F.path.wiki('index')).to.throwException(/^ENOENT/);
+      resetCommit(next);
+    }).catch(assert.ifError).done();
+  });
+
+  F.assert('model:page#parseDocument', next => {
+    page.parseDocument('$title foo\n$desc bar\n\n*body*').then(res => {
+      expect(res.header.title).to.be('foo');
+      expect(res.header.desc).to.be('bar');
+
+      // no need to test parsing, should be handled in parser testing
+      expect(res.body).to.be('<p><em>body</em></p>\n');
+      next();
+    }).catch(assert.ifError).done();
+  });
+
+  F.assert('model:page#history', next => {
+    // we're assuming the first commit created in 'exports.install' will be there.
+    page.history('/').then(history => {
+      expect(history).to.be.an('array');
+
+      let commit = history[history.length - 1];
+      expect(commit.author_name).to.be('Skribki');
+      expect(commit.author_email).to.be('skribki@localhost');
+      expect(commit.message).to.be('Update /index');
+
       next();
     }).catch(assert.ifError).done();
   });

--- a/tests/models/page.js
+++ b/tests/models/page.js
@@ -9,7 +9,7 @@ const fs    = require('fs'),
 const TEST_PATH = '/test~';
 
 function resetCommit(cb) {
-  F.repository.reset(['HEAD^1', '--hard'], cb);
+  F.repository.reset(['HEAD^1', '--hard', '--'], cb);
 }
 
 exports.run = () => {

--- a/tests/models/page.js
+++ b/tests/models/page.js
@@ -123,7 +123,7 @@ exports.run = () => {
       let commit = history[history.length - 1];
       expect(commit.author_name).to.be('Skribki');
       expect(commit.author_email).to.be('skribki@localhost');
-      expect(commit.message).to.be('Update /index');
+      expect(commit.message.startsWith('Initial Commit')).to.be(true);
 
       next();
     }).catch(assert.ifError).done();

--- a/tests/models/parsers.js
+++ b/tests/models/parsers.js
@@ -1,19 +1,20 @@
 'use strict';
 
-const assert = require('assert');
+const assert = require('assert'),
+      expect = require('expect.js');
 
 exports.run = () => {
 
-  F.assert('models:parsers:escape', next => {
+  F.assert('model:parsers:escape', next => {
     F.model('parsers/escape').run('<i>foo</i>').then(res => {
-      assert.equal(res, '&lt;i&gt;foo&lt;/i&gt;', 'should strip HTML tags');
+      expect(res).to.be('&lt;i&gt;foo&lt;/i&gt;');
       next();
     }).catch(assert.isError).done();
   });
 
-  F.assert('models:parsers:markdown', next => {
+  F.assert('model:parsers:markdown', next => {
     F.model('parsers/markdown').run('*italic* **bold**').then(res => {
-      assert.equal(res.trim(), '<p><em>italic</em> <strong>bold</strong></p>', 'should parse markdown');
+      expect(res.trim()).to.be('<p><em>italic</em> <strong>bold</strong></p>');
       next();
     }).catch(assert.isError).done();
   });

--- a/views/delete.pug
+++ b/views/delete.pug
@@ -1,7 +1,7 @@
 extends layout-sidebar.pug
 
 block header
-  #header.jumbotron
+  .jumbotron.jumbotron-header
     .container
       h1= translate('page.delete.title')
       h2= translate('page.delete.desc', [ url ])

--- a/views/error.pug
+++ b/views/error.pug
@@ -7,14 +7,17 @@ block header
       h2= translate('error.err.' + model.errno, [ model.url ])
 
 block content
-  if F.locked(model.url)
-    p= translate('error.body.locked')
-    a.btn.btn-lg(href='/')= translate('page.action.home')
-  else
-    p= translate('error.body.unlocked')
-    a.btn.btn-lg(href='?a=history')= translate('page.action.history')
-    a.btn.btn-lg(href='?a=create')= translate('page.action.create')
-  if model.info
-    hr
-    p= translate('error.body.info')
-    pre= model.info
+  .content-options.text-right
+    a(href='/')= translate('page.action.home')
+  .content-page
+    if F.locked(model.url)
+      p= translate('error.body.locked')
+      a.btn.btn-lg.btn-primary(href='/')= translate('page.action.home')
+    else
+      p= translate('error.body.unlocked')
+      a.btn.btn-lg.btn-primary(href='?a=history')= translate('page.action.history')
+      a.btn.btn-lg.btn-success(href='?a=create')= translate('page.action.create')
+    if model.info
+      hr
+      p= translate('error.body.info')
+      pre= model.info

--- a/views/error.pug
+++ b/views/error.pug
@@ -1,7 +1,7 @@
 extends layout-sidebar.pug
 
 block header
-  #header.jumbotron
+  .jumbotron.jumbotron-header
     .container
       h1= translate('error.header', [ model.errno ])
       h2= translate('error.err.' + model.errno, [ model.url ])

--- a/views/history.pug
+++ b/views/history.pug
@@ -1,7 +1,7 @@
 extends layout-sidebar.pug
 
 block header
-  #header.jumbotron
+  .jumbotron.jumbotron-header
     .container
       h1= translate('page.history.title')
       h2= translate('page.history.desc', [url])

--- a/views/layout-sidebar.pug
+++ b/views/layout-sidebar.pug
@@ -5,6 +5,7 @@ block body
     .container
       .row
         section#sidebar.col-xs-12.col-md-2
+          img(src=config.wiki.icon)
           block sidebar
             a.sidebar-lg.active(href='/') Wiki Home
             a.sidebar-md(href='/special/random') Random Page

--- a/views/layout-sidebar.pug
+++ b/views/layout-sidebar.pug
@@ -1,15 +1,15 @@
 extends layout.pug
 
 block body
-  #body
+  .section-body
     .container
       .row
-        section#sidebar.col-xs-12.col-md-2
+        section.section-sidebar.col-xs-12.col-md-2
           img(src=config.wiki.icon)
           block sidebar
             a.sidebar-lg.active(href='/') Wiki Home
             a.sidebar-md(href='/special/random') Random Page
             a.sidebar-md(href='/special/search') Page Search
             hr
-        section#content.col-xs-12.col-md-10
+        section.section-content.col-xs-12.col-md-10
           block content

--- a/views/layout.pug
+++ b/views/layout.pug
@@ -17,12 +17,12 @@ html
   body
     include layout/navbar.pug
     block header
-      #header.jumbotron
+      .jumbotron.jumbotron-header
         .container
           h1 Page Title
           h2 The page's description would go here.
     block banner
-      #banner
+      .banner
         .container
           p Welcome to Skribki!
           span.banner-dash &#8211;

--- a/views/page.pug
+++ b/views/page.pug
@@ -1,7 +1,7 @@
 extends layout-sidebar.pug
 
 block header
-  #header.jumbotron
+  .jumbotron.jumbotron-header
     .container
       h1= model.page.header.title
       h2= model.page.header.desc


### PR DESCRIPTION
*Changelog*
```
+ Added wiki icon to sidebar, configurable with `wiki.icon`
+ Added `scss-lint` to handle linting of styles
* Overhauled the page model to make it more reliable.
* Overhauled the views and stylesheets to coincide with the linter.
* Overhauled tests to use `expect.js` and be more reliable.
* Minor reformatting of the error view.
* Fixed `modules/scss.js` not outputting errors (not a production solution, only temporary)
* Fixed an issue with tests' git rollbacks being ambiguous (they still fail sometimes)
* The default value for the `auth.emails` config entry has been updated.
- Removed `g++-4.8` from apt install, fall back to default compiler
```