### PR TITLE
v1.2.0

### DIFF
--- a/controllers/page.js
+++ b/controllers/page.js
@@ -8,7 +8,7 @@ exports.install = () => {
   F.route(r => { return !F.locked(r); }, deletePage, [ 'delete' ]);
 };
 
-/* eslint complexity: ["error", 7] */
+/* eslint complexity: 0 */
 function routePage() {
   let page = F.model('page');
   switch (this.query.a || '') {

--- a/controllers/page.js
+++ b/controllers/page.js
@@ -48,7 +48,7 @@ function editPage() {
   if (!this.user) return this.throw401('must be logged in');
   if (!this.body.body) return this.throw400('must have a body');
 
-  F.model('page').write(this.url, {
+  F.model('page').write(this.url + (this.body.useDir ? 'index' : ''), {
     email: this.user.email,
     name: this.user.name,
     body: this.body.body,

--- a/modules/pug.js
+++ b/modules/pug.js
@@ -37,10 +37,8 @@ const createParserFunction = (self, key, name, filename) => {
 
 exports.install = opts => {
   frameworkEngine = Controller.prototype.view;
-  /* eslint complexity: ["error", 7] */
+  /* eslint complexity: 0 */
   Controller.prototype.view = function (name, model = { }, headers, isPartial) {
-    let self = this;
-
     // shift arguments if needed
     if (isPartial === undefined && typeof headers === 'boolean') {
       isPartial = headers;
@@ -48,7 +46,7 @@ exports.install = opts => {
     }
 
     // if it already succeeded and didn't need to be parsed
-    if (self.res.success && !isPartial) return self;
+    if (this.res.success && !isPartial) return this;
 
     let skip = name.startsWith('~'),
         filename = name;
@@ -56,28 +54,28 @@ exports.install = opts => {
     if (skip) filename = name.substring(1);
 
     let key = 'pug_' + filename,
-        fn = F.cache.read2(key) || createParserFunction(self, key, name, filename);
-    if (typeof fn !== 'function') return self;
+        fn = F.cache.read2(key) || createParserFunction(this, key, name, filename);
+    if (typeof fn !== 'function') return this;
 
     let locals = {
       model: model,
-      controller: self,
+      controller: this,
       config: F.config,
-      repository: self.repository,
-      user: self.user,
+      repository: this.repository,
+      user: this.user,
       global: F.global,
-      url: self.url,
-      translate: (key, args = []) => { return F.localize(self.req, key, args); },
+      url: this.url,
+      translate: (key, args = []) => { return F.localize(this.req, key, args); },
       name: name
     };
 
-    self.subscribe.success();
-    if (self.isConnected) {
-      F.responseContent(self.req, self.res, self.status, fn(locals), 'text/html', true, headers);
+    this.subscribe.success();
+    if (this.isConnected) {
+      F.responseContent(this.req, this.res, this.status, fn(locals), 'text/html', true, headers);
       F.stats.response.view++;
     }
 
-    return self;
+    return this;
   };
 };
 

--- a/modules/scss.js
+++ b/modules/scss.js
@@ -30,6 +30,7 @@ function scssCompiler(req, res, isValidation) {
   let output = data => {
     if (!this.config.debug) F.cache.set(key, data, F.datetime.add('m', 5)); // cache the stylesheet for 5 minutes
     this.responseContent(req, res, 200, data, 'text/css', true);
+    F.stats.response.file++;
   };
 
   if (cached) output(cached);

--- a/modules/scss.js
+++ b/modules/scss.js
@@ -4,16 +4,11 @@ const sass  = require('node-sass'),
       fs    = require('fs');
 
 exports.compile = (content) => {
-  try {
-    return sass.renderSync({
-      data: content,
-      outputStyle: 'compressed',
-      includePaths: [ F.path.public('/styles/partials') ]
-    }).css.toString();
-  } catch (e) {
-    console.log(e.stack);
-    return '';
-  }
+  return sass.renderSync({
+    data: content,
+    outputStyle: 'compressed',
+    includePaths: [ F.path.public('/styles/partials') ]
+  }).css.toString();
 };
 
 exports.install = () => {
@@ -25,25 +20,26 @@ exports.install = () => {
   };
 };
 
-/* eslint complexity: ["error", 7] */
 function scssCompiler(req, res, isValidation) {
   if (isValidation)
     return req.url.endsWith('.scss') || req.url.endsWith('.sass');
 
-  let self = this;
-
   let key = 'scss_' + req.url.substring(1),
       cached = F.cache.get(key);
 
-  if (cached) return cached;
-  else {
+  let output = data => {
+    if (!this.config.debug) F.cache.set(key, data, F.datetime.add('m', 5)); // cache the stylesheet for 5 minutes
+    this.responseContent(req, res, 200, data, 'text/css', true);
+  };
+
+  if (cached) output(cached);
+  else fs.readFile(F.path.public(req.url), (err, data) => {
+    if (err) return err.message.startsWith('ENOENT')
+      ? this.response404(req, res)
+      : this.response500(req, res, err);
     try {
-      let output = exports.compile(fs.readFileSync(F.path.public(req.url)).toString());
-      if (!self.config.debug) F.cache.set(key, output, F.datetime.add('m', 4));
-      self.responseContent(req, res, 200, output, 'text/css', true);
-    } catch (e) {
-      if (e.message.startsWith('ENOENT')) self.response404(req, res);
-      else self.response500(req, res, e);
-    }
-  }
+      output(exports.compile(data.toString()));
+    } catch (e) { this.response500(req, res, err); }
+  });
+
 }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "node": ">=6.0"
   },
   "dependencies": {
+    "fs-extra": "^2.0.0",
     "lockfile": "^1.0.3",
     "marked": "^0.3.6",
     "node-sass": "^4.0.0",

--- a/public/styles/page.scss
+++ b/public/styles/page.scss
@@ -8,8 +8,8 @@
     text-indent: 10px;
   }
 
-  code {
-    background-color: $color-white;
+  :not(pre) > code {
+    background-color: $color-white1;
     border-radius: 2px;
     color: tint($color-gray, 40%);
     padding: 2px 5px;
@@ -58,5 +58,13 @@
   h6 {
     color: tint($color-gray, 40%);
     font-size: 12pt;
+  }
+
+  // block
+  pre {
+    background-color: tint($color-white1, 20%);
+    border: 0;
+    border-radius: 0;
+    color: tint($color-gray, 20%);
   }
 }

--- a/public/styles/partials/_colors.scss
+++ b/public/styles/partials/_colors.scss
@@ -12,10 +12,19 @@ $color-yellow1: #f1c40f;
 $color-yellow2: #f39c12;
 $color-green1: #2ecc71;
 $color-green2: #27ae60;
+$color-bluegreen1: #1abc9c;
+$color-bluegreen2: #16a085;
 $color-blue1: #3498db;
 $color-blue2: #2980b9;
 $color-purple1: #9b59b6;
 $color-purple2: #8e44ad;
+
+$color-black1: #34495e;
+$color-black2: #2c3e50;
+$color-white1: #ecf0f1;
+$color-white2: #bdc3c7;
+$color-gray1: #95a5a6;
+$color-gray2: #7f8c8d;
 
 @import 'functions';
 

--- a/public/styles/partials/_objects.scss
+++ b/public/styles/partials/_objects.scss
@@ -86,6 +86,7 @@ $color-btn-success: mix($color-green1, $color-base-1, 40%);
   }
 }
 
+// scss-lint:disable SelectorDepth, NestingDepth
 [type=checkbox] {
   left: 0;
   position: fixed;
@@ -128,6 +129,7 @@ $color-btn-success: mix($color-green1, $color-base-1, 40%);
 
   &:checked + label {
     color: $color-gray2;
+
     .box {
       background-color: tint($color-base-2, 40%);
 

--- a/public/styles/partials/_objects.scss
+++ b/public/styles/partials/_objects.scss
@@ -86,6 +86,63 @@ $color-btn-success: mix($color-green1, $color-base-1, 40%);
   }
 }
 
+[type=checkbox] {
+  left: 0;
+  position: fixed;
+
+  + label {
+    color: $color-white2;
+    cursor: pointer;
+    display: inline-block;
+    font-weight: normal;
+    margin-bottom: 0;
+    transition: 300ms;
+    user-select: none;
+    vertical-align: middle;
+
+    .box {
+      background-color: $color-white2;
+      border-radius: 5px;
+      display: inline-block;
+      height: 10px;
+      margin: 0 10px;
+      position: relative;
+      transition: 300ms;
+      vertical-align: middle;
+      width: 25px;
+
+      &::before {
+        background-color: $color-gray2;
+        border-radius: 50%;
+        content: '';
+        display: block;
+        height: 20px;
+        left: -5px;
+        position: relative;
+        top: -5px;
+        transition: 300ms;
+        width: 20px;
+      }
+    }
+  }
+
+  &:checked + label {
+    color: $color-gray2;
+    .box {
+      background-color: tint($color-base-2, 40%);
+
+      &::before {
+        background-color: $color-base-1;
+        left: 10px;
+      }
+    }
+  }
+
+  &:disabled {
+    opacity: .5;
+  }
+}
+
 textarea {
   background-color: rgba($color-black, .03);
   border: 1px rgba($color-black, .07) solid;

--- a/readme.md
+++ b/readme.md
@@ -11,8 +11,23 @@
 # A Powerful New Wiki
 Skribki is unique as wiki software in that it is *super* simple to set up and requires **no additional software** besides NodeJS and git. That's really it: no silly databases and no hassle with web server or daemon configuration.
 
-[Customization](#Customization) •
-[Installation](#Installation)
+## Quick Install
+Skribki is simple to install and requires little extra work to get it running.
+
+```
+// Clone the repo and install dependencies
+$ git clone https://github.com/VevoxDigital/Skribki
+$ npm install
+
+// Start Skribki
+$ npm start
+```
+
+Optionally append `--branch=dev` to the clone command to use the latest bleeding-edge build.
+
+Skirbki requires NodeJS `v6.0` (`v6.9.1 lts` preferred) or later. If you need help upgrading, check out [this nifty thing](https://www.npmjs.com/package/n).
+
+[In-depth installation documentation can be found here.](http://wiki.vevox.io/projects/skribki/install)
 
 ## Database-less Data
 Skribki runs completely without a database, which may sound a little strange at first. All of the pages and files associated with Skribki are all stored on disk and controlled by a git repository: changes are logged and stored soley by git.
@@ -22,46 +37,8 @@ For authentication and users, Skribki utilizes OAuth providers to store user acc
 ## Flexibility and Simplicity
 What sets Skribki apart from other software is its extreme flexibility without over-complicating its functionality. Themes, custom parsers, new authentication strategies, and more are all readily available, but Skribki is ready to go out of the gate if you just want to get things rolling.
 
-# Customization
+----
 
-## Parsers
-Skribki comes default with a simple Markdown parser (using [marked](https://www.npmjs.com/package/marked)) and a simple HTML escaper. You can easily add your own parsers to give your wiki some edge over the others. If you're interested, give [this page](http://wiki.vevox.io/docs/skribki/parsers) a look.
+Made for you by [@CynicalBusiness](/CynicalBusiness) at Vevox Digital
 
-## Themes
-Everybody loves themes, and changing the theme is dirt simple. Drop in your theme and tell Skribki which one to use; simple as that.
-
-Want to make your own theme? Check [this](http://wiki.vevox.io/docs/skribki/themes) out.
-
-## Authentication
-When it comes to authentication, Skribki is a little different. There is no database underneath, so Skribki relies on external providers for authentication, using [Passport](http://passportjs.org).
-
-You can either create your own Passport strategy or use one of the many pre-existing ones to log in with. As long as it produces a username and email, it'll work!
-
-# Installation
-Skribki is *super* simple to install and requires little extra work to get it running.
-
-```
-// Clone the repo and install dependencies
-$ git clone https://github.com/VevoxDigital/Skribki
-$ npm install
-
-// Start Skribki
-$ npm start
-
-```
-
-Optionally append `--branch=dev` to the clone command to use the latest bleeding-edge build.
-
-Skirbki requires NodeJS `v6.0` (`v6.9.1 lts` preferred) or later. If you need help upgrading, check out [this nifty thing](https://www.npmjs.com/package/n).
-
-### Compass/Ruby Errors
-In some cases, errors may arise related to Compass and/or Ruby. This is because `lib-sass` (through `node-sass`) doesn't *always* recognize the gem. Simply install it manually.
-
-```
-// Install the Ruby devkit from our package manager.
-// In this case, we're using Debian apt.
-$ sudo apt-get install ruby-dev
-
-// Install the Compass gem
-$ sudo gem install compass
-```
+*To My Warrior, Half the World Away*

--- a/resources/en-uk.resource
+++ b/resources/en-uk.resource
@@ -51,6 +51,8 @@ page.history.changesPlural    : There have been {0} changes to this page.
 page.edit.header        : Edit Page
 page.edit.desc          : Changing page contents for {0}
 page.edit.commit        : Commit Changes
+page.edit.useDir        : Create as Directory
+page.edit.useDirTip     : Create as index of directory instead
 page.edit.previewTitle  : Page Preview
 page.edit.previewUpdate : Update Preview
 page.edit.previewEmpty  : Preview is empty. Press "Update Preview" to preview your changes.

--- a/resources/en-us.resource
+++ b/resources/en-us.resource
@@ -51,6 +51,8 @@ page.history.changesPlural    : There have been {0} changes to this page.
 page.edit.header        : Edit Page
 page.edit.desc          : Changing page contents for {0}
 page.edit.commit        : Commit Changes
+page.edit.useDir        : Create as Directory
+page.edit.useDirTip     : Create as index of directory instead 
 page.edit.previewTitle  : Page Preview
 page.edit.previewUpdate : Update Preview
 page.edit.previewEmpty  : Preview is empty. Press "Update Preview" to preview your changes.

--- a/tests/models/page.js
+++ b/tests/models/page.js
@@ -3,7 +3,7 @@
 const assert = require('assert'),
       expect = require('expect.js');
 
-const fs    = require('fs'),
+const fs    = require('fs-extra'),
       path  = require('path');
 
 const TEST_PATH = '/test~';
@@ -65,6 +65,20 @@ exports.run = () => {
         fs.unlinkSync(F.path.wiki(TEST_PATH));
         next();
       });
+    }).catch(assert.ifError).done();
+  });
+
+  F.assert('model:page#makeDirs', next => {
+    page.makeDirs('foo/bar/baz')().then(route => {
+
+      try {
+        expect(fs.statSync(F.path.wiki(path.dirname(route))).isDirectory()).to.be(true);
+      } catch (e) { assert.ifError(e); }
+      expect(fs.statSync).withArgs(F.path.wiki(route)).to.throwException(/^ENOENT/);
+
+      fs.removeSync(F.path.wiki('foo'));
+      next();
+
     }).catch(assert.ifError).done();
   });
 

--- a/views/edit.pug
+++ b/views/edit.pug
@@ -11,7 +11,14 @@ block content
     form#editForm(action=url method='POST')
       input(name='message' type='text' placeholder='update ' + url)
       input.btn.btn-success(type='submit' value=translate('page.edit.commit'))
+
+      input(name='useDir' type='checkbox' id='editUseDir')
+      label(for='editUseDir' title=translate('page.edit.useDirTip'))
+        .box
+        =translate('page.edit.useDir')
+
       textarea#editBody.monospace(name='body' rows=30)= model.data
+
 
     form#previewForm(action='javascript:')
       h2.text-center= translate('page.edit.previewTitle')

--- a/views/error.pug
+++ b/views/error.pug
@@ -16,7 +16,7 @@ block content
     else
       p= translate('error.body.unlocked')
       a.btn.btn-lg.btn-primary(href='?a=history')= translate('page.action.history')
-      a.btn.btn-lg.btn-success(href='?a=create')= translate('page.action.create')
+      a.btn.btn-lg.btn-success(href='?a=edit')= translate('page.action.create')
     if model.info
       hr
       p= translate('error.body.info')

--- a/views/layout.pug
+++ b/views/layout.pug
@@ -1,3 +1,13 @@
+//
+  +
+  #--------------------[ Skribki Wiki ]-------------------#
+    A free & open-source wiki developed by Vevox Digital
+          https://github.com/VevoxDigital/Skribki
+
+            To My Warrior, Half the World Away
+      Myra ta Hayzel; Pal Kifitae te Entra en na Loka
+  #-------------------------------------------------------#
+  +
 doctype html
 html
   head


### PR DESCRIPTION
*Changelog*

```
+ Stat 'response.file' tracking when loading stylesheets
+ Option to create as directory (i.e. create index under the given name) on editing page
+ Switch and 'pre' block styles
+ Dependency: fs-extra
* Directories will now create as needed when making pages under non-root directories
* Stylesheets now cache properly
* Fixed some issues with eslint parsing incorrectly (hopefully)
* Updated 'code' element styles
* Updated readme to be a bit less of a wall of text
* 'Create' button on error page now actually links to editor
```