### PR TITLE
v1.4.2

### DIFF
--- a/controllers/page.js
+++ b/controllers/page.js
@@ -49,7 +49,7 @@ function routeViewEdit () {
 
   PAGE.read(this.url).then(data => {
     this.repository.title = U.localize(this.req, 'title.page.edit')
-    this.view('edit', { data: data })
+    this.view('edit', { data: data, canUseDir: !data })
   }).catch(err => { this.throw500(err) }).done()
 }
 

--- a/definitions/routing.js
+++ b/definitions/routing.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const url = require('url')
+
 F.middleware('public-files', (req, res, next) => {
   if (req.url.startsWith('/public')) {
     return res.redirect(req.url.substring(7))
@@ -7,6 +9,14 @@ F.middleware('public-files', (req, res, next) => {
   next()
 })
 F.use('public-files')
+
+F.middleware('route-normalizer', (req, res, next) => {
+  let u = url.parse(req.url)
+  if (u.pathname.endsWith('/') && u.pathname.length > 1) {
+    res.redirect(u.pathname.slice(0, -1) + (u.search || '') + (u.hash || ''), true)
+  } else return next()
+})
+F.use('route-normalizer')
 
 F.middleware('route-logging', (req, res, next, opts, controller) => {
   res.on('finish', () => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skribki",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "An open-source wiki software based on git.",
   "main": "release.js",
   "private": true,

--- a/public/styles/layout.scss
+++ b/public/styles/layout.scss
@@ -25,6 +25,11 @@ body {
   }
 }
 
+.content-options {
+  float: right;
+  padding: 8px;
+}
+
 // generic styles
 @media (min-width: 768px) {
   body {

--- a/resources/en-uk.resource
+++ b/resources/en-uk.resource
@@ -54,7 +54,8 @@ page.history.changesSingular  : There has been 1 change to this page.
 page.history.changesPlural    : There have been {0} changes to this page.
 
 // edit page
-page.edit.header        : Edit Page
+page.edit.header.edit   : Editing Page
+page.edit.header.create : Creating Page
 page.edit.desc          : Changing page contents for {0}
 page.edit.commit        : Commit Changes
 page.edit.useDir        : Create as Directory

--- a/resources/en-us.resource
+++ b/resources/en-us.resource
@@ -54,7 +54,8 @@ page.history.changesSingular  : There has been 1 change to this page.
 page.history.changesPlural    : There have been {0} changes to this page.
 
 // edit page
-page.edit.header        : Edit Page
+page.edit.header.edit   : Editing Page
+page.edit.header.create : Creating Page
 page.edit.desc          : Changing page contents for {0}
 page.edit.commit        : Commit Changes
 page.edit.useDir        : Create as Directory

--- a/themes/vevox-blue/_layout.scss
+++ b/themes/vevox-blue/_layout.scss
@@ -16,16 +16,30 @@
   .content-options > a {
     color: $color-base-1;
     display: inline-block;
-    padding: 5px 10px;
-    transition: opacity 250ms;
+    padding: 0 10px;
+    transition: color 250ms;
 
     &:hover,
     &:focus {
-      color: $color-base-1;
-      opacity: .7;
+      color: tint($color-base-1, 50%);
       text-decoration: none;
     }
 
     &.danger { color: $color-red1; }
+  }
+}
+
+.breadcrumb {
+  background-color: transparent;
+
+  .breadcrumb-item > a {
+    color: $color-base-1;
+    transition: color 250ms;
+
+    &:hover,
+    &:focus {
+      color: tint($color-base-1, 50%);
+      text-decoration: none;
+    }
   }
 }

--- a/themes/vevox-blue/_navbar.scss
+++ b/themes/vevox-blue/_navbar.scss
@@ -1,5 +1,9 @@
 .navbar-brand {
   padding: 20px 15px;
+
+  > img {
+    padding-right: 6px;
+  }
 }
 
 .navbar-default {

--- a/views/directory.pug
+++ b/views/directory.pug
@@ -1,12 +1,14 @@
 extends layout-sidebar.pug
 
 include layout/page-actions.pug
+include layout/breadcrumbs.pug
 
 block header
   +header(translate('page.directory.title'), translate('page.directory.desc', url))
 
 block content
   +page-actions({ history: '?a=history', create: user && '?a=edit' })
+    +breadcrumbs
     h1= translate('page.directory.header')
     p= translate('page.directory.info', url)
     each files, letter in model.files

--- a/views/edit.pug
+++ b/views/edit.pug
@@ -2,6 +2,9 @@ extends layout-sidebar.pug
 
 include layout/page-actions.pug
 
+append scripts
+  link(rel='stylesheet' href='//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.9.0/styles/solarized-light.min.css')
+
 block header
 block banner
 block content

--- a/views/edit.pug
+++ b/views/edit.pug
@@ -6,16 +6,17 @@ block header
 block banner
 block content
   +page-actions({ back: url })
-    h1.text-center= translate('page.edit.header')
+    h1.text-center= model.canUseDir ? translate('page.edit.header.create') : translate('page.edit.header.edit')
     h3.text-center= translate('page.edit.desc', url)
     form#editForm(action=url method='POST')
       input(name='message' type='text' placeholder='update ' + url)
       input.btn.btn-success(type='submit' value=translate('page.edit.commit'))
 
-      input(name='useDir' type='checkbox' id='editUseDir')
-      label(for='editUseDir' title=translate('page.edit.useDirTip'))
-        .box
-        =translate('page.edit.useDir')
+      if model.canUseDir
+        input(name='useDir' type='checkbox' id='editUseDir')
+        label(for='editUseDir' title=translate('page.edit.useDirTip'))
+          .box
+          =translate('page.edit.useDir')
 
       textarea#editBody.monospace(name='body' rows=30)= model.data
 

--- a/views/history.pug
+++ b/views/history.pug
@@ -1,12 +1,14 @@
 extends layout-sidebar.pug
 
 include layout/page-actions.pug
+include layout/breadcrumbs.pug
 
 block header
   +header(translate('page.history.title'), translate('page.history.desc', url))
 
 block content
   +page-actions({ back: url })
+    +breadcrumbs
     h1= translate('page.history.header')
     if model.history.length === 1
       p= translate('page.history.changesSingular')

--- a/views/layout/breadcrumbs.pug
+++ b/views/layout/breadcrumbs.pug
@@ -2,6 +2,8 @@ mixin breadcrumbs
   - var crumbs = url.substring(1).slice(0, -1).split(/\//g)
   - var link = '/'
   ol.breadcrumb
+    li.breadcrumb-item
+      a(href = '/')= 'home'
     while crumbs.length > 1
       - var c = crumbs.shift()
       li.breadcrumb-item

--- a/views/layout/breadcrumbs.pug
+++ b/views/layout/breadcrumbs.pug
@@ -1,0 +1,10 @@
+mixin breadcrumbs
+  - var crumbs = url.substring(1).slice(0, -1).split(/\//g)
+  - var link = '/'
+  ol.breadcrumb
+    while crumbs.length > 1
+      - var c = crumbs.shift()
+      li.breadcrumb-item
+        - link += c + '/'
+        a(href = link.slice(0, -1))= c
+    li.breadcrumb-item.active= crumbs[0]

--- a/views/layout/page-actions.pug
+++ b/views/layout/page-actions.pug
@@ -1,5 +1,5 @@
 mixin page-actions(actions)
-  .content-options.text-right
+  .content-options
     each url, action in actions || { }
       if (url)
         a(href=url)= translate('page.action.' + action)

--- a/views/page.pug
+++ b/views/page.pug
@@ -1,6 +1,7 @@
 extends layout-sidebar.pug
 
 include layout/page-actions.pug
+include layout/breadcrumbs.pug
 
 append scripts
   link(rel='stylesheet' href='//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.9.0/styles/solarized-light.min.css')
@@ -10,6 +11,7 @@ block header
 
 block content
   +page-actions({ history: '?a=history', edit: user && '?a=edit', delete: user && '?a=delete' })
+    +breadcrumbs
     != model.page.body
 
 append sidebar


### PR DESCRIPTION
*Changelog*
```
+ Breadcrumbs now appear on the top of the page

* Trailing URL slashes are now consistently not there (as opposed to sometimes appearing)
* The edit page now distinguishes creation versus editing
* The "Create as Directory" button is now hidden if "editing" instead of "creating"
* Code block syntax highlighting now works in the edit preview
```